### PR TITLE
Use new Dinero Endpoint to better Utilize Dinero Ocr Engine

### DIFF
--- a/lib/dinero.rb
+++ b/lib/dinero.rb
@@ -25,7 +25,7 @@ class Dinero
   def create_purchase(file_id: nil, notes: nil)
     request do
       response = RestClient.post "https://api.dinero.dk/v1.1/#{@organization_id}/vouchers/purchase", { FileGuid: file_id, Lines: [], PurchaseType: "credit", Notes: notes }.to_json, { Authorization: "Bearer #{@auth_token}", accept: :json, content_type: :json }
-      JSON.parse(response)['VoucherGuid']
+      JSON.parse(response)['Guid']
     end
   end
 

--- a/lib/dinero.rb
+++ b/lib/dinero.rb
@@ -22,9 +22,9 @@ class Dinero
     end
   end
 
-  def create_purchase(date: DateTime.now, file_id: nil, notes: nil)
+  def create_purchase(file_id: nil, notes: nil)
     request do
-      response = RestClient.post "https://api.dinero.dk/v1/#{@organization_id}/vouchers/purchase", { VoucherDate: date.strftime('%Y-%m-%d'), FileGuid: file_id, Notes: notes }.to_json, { Authorization: "Bearer #{@auth_token}", accept: :json, content_type: :json }
+      response = RestClient.post "https://api.dinero.dk/v1.1/#{@organization_id}/vouchers/purchase", { FileGuid: file_id, Lines: [], PurchaseType: "credit", Notes: notes }.to_json, { Authorization: "Bearer #{@auth_token}", accept: :json, content_type: :json }
       JSON.parse(response)['VoucherGuid']
     end
   end


### PR DESCRIPTION
Ved at bruge det nye Endpoint hos Dinero og lade vær med at sende end VoucherDate med vil Dinero's OCR Maskine udfylde det meste af bilaget for en. 

Det eneste det kræver at at ændre Endpoint og lave Post modellen lidt om til: 
```
{
  "FileGuid": "SOMEFILEGUID",
  "PurchaseType": "credit",
  "Lines": []
}
```

Før: 
![image](https://user-images.githubusercontent.com/15048221/53655295-0de9ff00-3c50-11e9-9176-4691d4c125a8.png)

Efter:
![image](https://user-images.githubusercontent.com/15048221/53655272-fca0f280-3c4f-11e9-9e5b-a08b01629859.png)
